### PR TITLE
Remove rack exception

### DIFF
--- a/lib/exceptions.rb
+++ b/lib/exceptions.rb
@@ -13,6 +13,7 @@ module Exceptions
     autoload :Logger,      'exceptions/backends/logger'
     autoload :LogResult,   'exceptions/backends/log_result'
     autoload :Honeybadger, 'exceptions/backends/honeybadger'
+    autoload :Context,     'exceptions/backends/context'
   end
 
   class << self

--- a/lib/exceptions.rb
+++ b/lib/exceptions.rb
@@ -40,13 +40,6 @@ module Exceptions
       backend.clear_context
     end
 
-    # Public: Notify a rack exception.
-    #
-    # Returns a Result object.
-    def rack_exception(exception, env)
-      backend.rack_exception exception, env
-    end
-
     # Public: The configuration object.
     #
     # Returns a Configuration instance.

--- a/lib/exceptions/backend.rb
+++ b/lib/exceptions/backend.rb
@@ -28,12 +28,5 @@ module Exceptions
     # Returns nothing.
     def clear_context
     end
-
-    # Public: Called by the Rack middleware when an exception is raised.
-    #
-    # Returns and object satisfying the Result interface.
-    def rack_exception(exception, env)
-      notify(exception)
-    end
   end
 end

--- a/lib/exceptions/backends/context.rb
+++ b/lib/exceptions/backends/context.rb
@@ -1,0 +1,27 @@
+module Exceptions
+  module Backends
+    # Public: Context is a middleware that will add the given context options
+    # whenever an exception is reported.
+    class Context < Backend
+      attr_reader :backend, :extra
+
+      def initialize(backend, context = {})
+        @backend = backend
+        @extra = context
+      end
+
+      def notify(exception, *args)
+        backend.context extra
+        backend.notify(exception, *args)
+      end
+
+      def context(*args)
+        backend.context(*args)
+      end
+
+      def clear_context(*args)
+        backend.clear_context(*args)
+      end
+    end
+  end
+end

--- a/lib/exceptions/backends/honeybadger.rb
+++ b/lib/exceptions/backends/honeybadger.rb
@@ -12,6 +12,7 @@ module Exceptions
       end
 
       def notify(exception, options = {})
+        return if options[:rack_env] && rack_ignore?(options[:rack_env])
         defaults = { backtrace: caller.drop(1) }
         if id = honeybadger.notify_or_ignore(exception, defaults.merge(options))
           Result.new id
@@ -28,18 +29,20 @@ module Exceptions
         honeybadger.clear!
       end
 
-      def rack_exception(exception, env)
-        notify(exception, rack_env: env) unless honeybadger.
-          configuration.
-          ignore_user_agent.
-          flatten.
-          any? { |ua| ua === env['HTTP_USER_AGENT'] }
-      end
-
       class Result < ::Exceptions::Result
         def url
           "https://www.honeybadger.io/notice/#{id}"
         end
+      end
+
+      private
+
+      def rack_ignore?(env)
+         return honeybadger.
+          configuration.
+          ignore_user_agent.
+          flatten.
+          any? { |ua| ua === env['HTTP_USER_AGENT'] }
       end
     end
   end

--- a/lib/exceptions/backends/log_result.rb
+++ b/lib/exceptions/backends/log_result.rb
@@ -18,12 +18,6 @@ module Exceptions
         end
       end
 
-      def rack_exception(exception, env)
-        backend.rack_exception(exception, env).tap do |result|
-          log exception, result
-        end
-      end
-
       def context(*args)
         backend.context(*args)
       end

--- a/lib/rack/exceptions.rb
+++ b/lib/rack/exceptions.rb
@@ -9,7 +9,7 @@ module Rack
       begin
         response = @app.call(env)
       rescue Exception => e
-        backend.rack_exception(e, env)
+        backend.notify(e, rack_env: env)
         raise
       end
 

--- a/spec/exceptions/backends/context_spec.rb
+++ b/spec/exceptions/backends/context_spec.rb
@@ -1,0 +1,16 @@
+require 'spec_helper'
+
+describe Exceptions::Backends::Context do
+  let(:backend) { double(Exceptions::Backend) }
+  let(:middleware) do
+    described_class.new backend, foo: 'bar'
+  end
+
+  describe '#notify' do
+    it 'sets the context' do
+      expect(backend).to receive(:context).with(foo: 'bar')
+      expect(backend).to receive(:notify).with(boom)
+      middleware.notify(boom)
+    end
+  end
+end


### PR DESCRIPTION
Having the `rack_exception` method always felt a little bloated, and made it harder to write middleware. This removes it and also adds a `Context` middleware you can use to add global context to any exception that's reported.

Going to use this for https://github.com/remind101/r101-api/pull/4788