### PR TITLE
Update to be compatible w HB 2

### DIFF
--- a/lib/exceptions/backends/honeybadger.rb
+++ b/lib/exceptions/backends/honeybadger.rb
@@ -2,7 +2,7 @@ require 'honeybadger'
 
 module Exceptions
   module Backends
-    # Public: The Honeybadger backend is a Backend implementation that sends the 
+    # Public: The Honeybadger backend is a Backend implementation that sends the
     # exception to Honeybadger.
     class Honeybadger < Backend
       attr_reader :honeybadger
@@ -11,38 +11,26 @@ module Exceptions
         @honeybadger = honeybadger
       end
 
-      def notify(exception, options = {})
-        return if options[:rack_env] && rack_ignore?(options[:rack_env])
-        defaults = { backtrace: caller.drop(1) }
-        if id = honeybadger.notify_or_ignore(exception, defaults.merge(options))
-          Result.new id
+      def notify(exception_or_opts, opts = {})
+        if id = honeybadger.notify(exception_or_opts, opts)
+          Result.new(id)
         else
           BadResult.new
         end
       end
 
       def context(ctx)
-        honeybadger.context ctx
+        honeybadger.context(ctx)
       end
 
       def clear_context
-        honeybadger.clear!
+        honeybadger.context.clear!
       end
 
       class Result < ::Exceptions::Result
         def url
           "https://www.honeybadger.io/notice/#{id}"
         end
-      end
-
-      private
-
-      def rack_ignore?(env)
-         return honeybadger.
-          configuration.
-          ignore_user_agent.
-          flatten.
-          any? { |ua| ua === env['HTTP_USER_AGENT'] }
       end
     end
   end


### PR DESCRIPTION
This brings the HB backend up to date with HB as of 2.7.2. Also it removes the user agent logic, it doesn't really belong in the backend. A better place for it is in the middleware. HB's native middleware does this for example.