### PR TITLE
Better exceptions middleware

### DIFF
--- a/exceptions.gemspec
+++ b/exceptions.gemspec
@@ -23,4 +23,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec', '~> 3.1.0'
   spec.add_development_dependency 'honeybadger', '~> 1.9.5'
   spec.add_development_dependency 'rollbar', '~> 2.14'
+  spec.add_development_dependency 'sinatra', '>= 1.4'
+  spec.add_development_dependency 'rails', '>= 4.2'
+  spec.add_development_dependency 'rack-test', '~> 0.6'
 end

--- a/lib/exceptions.rb
+++ b/lib/exceptions.rb
@@ -7,14 +7,15 @@ require 'rack/exceptions'
 
 module Exceptions
   module Backends
+    autoload :Context,     'exceptions/backends/context'
+    autoload :Honeybadger, 'exceptions/backends/honeybadger'
+    autoload :LogResult,   'exceptions/backends/log_result'
+    autoload :Logger,      'exceptions/backends/logger'
+    autoload :Multi,       'exceptions/backends/multi'
     autoload :Null,        'exceptions/backends/null'
     autoload :Raiser,      'exceptions/backends/raiser'
-    autoload :Multi,       'exceptions/backends/multi'
-    autoload :Logger,      'exceptions/backends/logger'
-    autoload :LogResult,   'exceptions/backends/log_result'
-    autoload :Honeybadger, 'exceptions/backends/honeybadger'
     autoload :Rollbar,     'exceptions/backends/rollbar'
-    autoload :Context,     'exceptions/backends/context'
+    autoload :Test,        'exceptions/backends/test'
   end
 
   class << self

--- a/lib/exceptions/backends/test.rb
+++ b/lib/exceptions/backends/test.rb
@@ -1,0 +1,18 @@
+module Exceptions
+  module Backends
+    # Public: Test is an implementation of the Backend interface that accumulates exceptions.
+    class Test < Backend
+      attr_reader :reported_exceptions
+
+      def initialize
+        @reported_exceptions = []
+      end
+
+      def notify(exception, options = {})
+        @reported_exceptions << exception
+        Result.new(@reported_exceptions.count - 1)
+      end
+    end
+  end
+end
+

--- a/lib/rack/exceptions.rb
+++ b/lib/rack/exceptions.rb
@@ -13,6 +13,11 @@ module Rack
         raise
       end
 
+      framework_exception = framework_exception(env)
+      if framework_exception
+        backend.notify(framework_exception, rack_env: env)
+      end
+
       response
     ensure
       backend.clear_context
@@ -22,6 +27,10 @@ module Rack
 
     def backend
       @backend ||= ::Exceptions.configuration.backend
+    end
+
+    def framework_exception(env)
+      env['action_dispatch.exception'] || env['rack.exception'] || env['sinatra.error']
     end
   end
 end

--- a/spec/rack/exceptions_spec.rb
+++ b/spec/rack/exceptions_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Rack::Exceptions, foo: true do
+describe Rack::Exceptions do
   let(:response) { [200, {}, []] }
   let(:app) { double('app', call: response) }
   let(:middleware) { described_class.new app }

--- a/spec/rack/rails_spec.rb
+++ b/spec/rack/rails_spec.rb
@@ -1,0 +1,42 @@
+require 'spec_helper'
+
+require 'logger'
+require 'rack/test'
+require 'rails'
+require 'action_controller/railtie'
+require 'action_dispatch/middleware/show_exceptions'
+
+describe Rack::Exceptions, backend: :test do
+  include Rack::Test::Methods
+
+  class CustomError < StandardError; end
+
+  class BoomsController < ActionController::Base
+    def show
+      raise CustomError, 'what the fun'
+    end
+  end
+
+  class RailsApp < Rails::Application
+    config.secret_key_base = 'not so secret after all, is it?'
+    config.middleware.use Rack::Exceptions
+    config.middleware.use ActionDispatch::ShowExceptions, proc { |env| [500, {}, "oops"] }
+
+    routes.draw do
+      get '/boom', to: 'booms#show'
+    end
+  end
+
+  Rails.logger = Logger.new(STDERR)
+  Rails.backtrace_cleaner.remove_filters!
+
+  def app
+    RailsApp
+  end
+
+  it 'tracks the error when an exception is raised' do
+    get('/boom')
+    expect(backend.reported_exceptions).to include(an_instance_of(CustomError))
+  end
+end
+

--- a/spec/rack/sinatra_spec.rb
+++ b/spec/rack/sinatra_spec.rb
@@ -1,0 +1,29 @@
+require 'spec_helper'
+
+require 'rack/test'
+require 'sinatra/base'
+
+describe Rack::Exceptions, backend: :test do
+  include Rack::Test::Methods
+
+  class CustomError < StandardError; end
+
+  class SinatraApp < Sinatra::Base
+    set :show_exceptions, false # production
+
+    use Rack::Exceptions
+
+    get '/boom' do
+      raise CustomError, 'what the fun'
+    end
+  end
+
+  def app
+    SinatraApp.new
+  end
+
+  it 'tracks the error when an exception is raised' do
+    get('/boom')
+    expect(backend.reported_exceptions).to include(an_instance_of(CustomError))
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -25,7 +25,8 @@ BACKENDS = {
   honeybadger: Exceptions::Backends::Honeybadger.new,
   rollbar:     Exceptions::Backends::Rollbar.new,
   multi:       Exceptions::Backends::Multi.new(Exceptions::Backends::Null.new),
-  logger:      Exceptions::Backends::Logger.new
+  logger:      Exceptions::Backends::Logger.new,
+  test:        Exceptions::Backends::Test.new
 }
 
 Exceptions.configure do |config|


### PR DESCRIPTION
As of current, the exceptions middleware is not particularly useful in production Rails/Sinatra apps, because those frameworks capture exceptions in order to provider a valid http response.