### PR TITLE
fix custom Rollbar::Response not having all the methods

### DIFF
--- a/lib/exceptions/backends/honeybadger.rb
+++ b/lib/exceptions/backends/honeybadger.rb
@@ -13,7 +13,7 @@ module Exceptions
 
       def notify(exception_or_opts, opts = {})
         if id = honeybadger.notify(exception_or_opts, opts)
-          Result.new(id)
+          wrap_rollbar_result(id)
         else
           BadResult.new
         end
@@ -27,10 +27,8 @@ module Exceptions
         honeybadger.context.clear!
       end
 
-      class Result < ::Exceptions::Result
-        def url
-          "https://www.honeybadger.io/notice/#{id}"
-        end
+      def wrap_rollbar_result(id)
+        Result.new(id, "https://www.honeybadger.io/notice/#{id}")
       end
     end
   end

--- a/lib/exceptions/result.rb
+++ b/lib/exceptions/result.rb
@@ -11,12 +11,9 @@ module Exceptions
   class Result
     attr_reader :id, :url
 
-    def initialize(id = nil)
+    def initialize(id = nil, url = nil)
       @id = id
-    end
-
-    def url
-      @url ||= ""
+      @url = url
     end
 
     def ok?


### PR DESCRIPTION
fixes all these:
https://rollbar.com/Remind/r101-api/items/?activated_from=&activated_to=&assigned_user=&date_from=&date_to=&framework=&environment=production&level=critical&level=error&level=warning&level=info&level=debug&offset=0&query=undefined%20method%20ok&sort=last_desc&status=