### PR TITLE
deep_dup => dup

### DIFF
--- a/lib/exceptions/backends/multi.rb
+++ b/lib/exceptions/backends/multi.rb
@@ -1,5 +1,3 @@
-require 'exceptions/util'
-
 module Exceptions
   module Backends
     # Public: Multi is an implementation of the Backend interface for wrapping multiple
@@ -12,7 +10,7 @@ module Exceptions
       end
 
       def notify(*args)
-        results = backends.map { |be| be.notify(*Util.deep_dup(args)) }
+        results = backends.map { |be| be.notify(*args.dup) }
         MultiResult.new results.map(&:id), results.map(&:url)
       end
 

--- a/lib/exceptions/util.rb
+++ b/lib/exceptions/util.rb
@@ -1,7 +1,0 @@
-module Exceptions
-  class Util
-    def self.deep_dup(obj)
-      Marshal.load(Marshal.dump(obj))
-    end
-  end
-end


### PR DESCRIPTION
fixes bug that @v-yarotsky noticed inside of r101-phonecalls.

```ruby
App 75 stderr: [ 2017-04-18 18:18:12.7523 93/0x0000000153cea0(Worker 1) utils.rb:87 ]: *** Exception TypeError in Rack application object (can't dump UNIXSocket) (process 93, thread 0x0000000153cea0(Worker 1)):
App 75 stderr:  from /usr/local/bundle/bundler/gems/exceptions-38eeb6aca14d/lib/exceptions/util.rb:4:in `dump'
App 75 stderr:  from /usr/local/bundle/bundler/gems/exceptions-38eeb6aca14d/lib/exceptions/util.rb:4:in `deep_dup'
App 75 stderr:  from /usr/local/bundle/bundler/gems/exceptions-38eeb6aca14d/lib/exceptions/backends/multi.rb:15:in `block in notify'
App 75 stderr:  from /usr/local/bundle/bundler/gems/exceptions-38eeb6aca14d/lib/exceptions/backends/multi.rb:15:in `map'
App 75 stderr:  from /usr/local/bundle/bundler/gems/exceptions-38eeb6aca14d/lib/exceptions/backends/multi.rb:15:in `notify'
[ 2017-04-18 18:18:12.7524 23/7f3349ffb700 age/Cor/Con/InternalUtils.cpp:112 ]: [Client 8-1] Sending 502 response: application did not send a complete response
App 75 stderr:  from /usr/local/bundle/bundler/gems/exceptions-38eeb6aca14d/lib/exceptions/backends/context.rb:15:in `notify'
App 75 stderr:  from /usr/local/bundle/bundler/gems/exceptions-38eeb6aca14d/lib/exceptions/backends/log_result.rb:16:in `notify'
App 75 stderr:  from /usr/local/bundle/bundler/gems/exceptions-38eeb6aca14d/lib/rack/exceptions.rb:12:in `rescue in call'
App 75 stderr:  from /usr/local/bundle/bundler/gems/exceptions-38eeb6aca14d/lib/rack/exceptions.rb:9:in `call'
```