### PR TITLE
fixes for manual reporting

### DIFF
--- a/lib/exceptions/backends/rollbar.rb
+++ b/lib/exceptions/backends/rollbar.rb
@@ -19,10 +19,10 @@ module Exceptions
       end
 
       def notify(exception = nil, level: 'error', error_class: nil,
-                 rack_env: nil, error_message: nil, parameters: {}, context: {})
+                 error_message: nil, parameters: {}, context: {})
         err = maybe_turn_into_exception(exception || error_class, error_message)
         extra = [DEFAULT_NOTIFY_ARGS, parameters, context].reduce(&:merge)
-        rollbar.scoped(rollbar_scope(rack_env)) do
+        rollbar.scoped(rack_env) do
           wrap_rollbar_result(rollbar.log(level, err, error_message, extra))
         end
       end
@@ -66,8 +66,8 @@ module Exceptions
         Result.new(id, "https://rollbar.com/instance/uuid?uuid=#{id}")
       end
 
-      def rollbar_scope(env)
-        if env
+      def rack_env
+        if env = ::Rack::Exceptions.rack_env
           {request: RollbarExtractor.extract_request_data_from_rack(env)}
         else
           {}

--- a/lib/exceptions/backends/rollbar.rb
+++ b/lib/exceptions/backends/rollbar.rb
@@ -8,7 +8,7 @@ module Exceptions
     class Rollbar
       DEFAULT_NOTIFY_ARGS = {
         # without this, rollbar won't ignore the error classes defined in
-        # config/initializers/exceptions.rb
+        # `config.exception_level_filters`
         use_exception_level_filters: true
       }
 

--- a/lib/rack/exceptions.rb
+++ b/lib/rack/exceptions.rb
@@ -1,6 +1,6 @@
 module Rack
   class Exceptions
-    # XXX: applications are typically configured with a single global instance
+    # applications are typically configured with a single global instance
     # of the exceptions reporter. use a thread local to store the current rack
     # so different threads don't see the same request info
     def self.rack_env

--- a/lib/rack/exceptions.rb
+++ b/lib/rack/exceptions.rb
@@ -1,26 +1,36 @@
 module Rack
   class Exceptions
+    # XXX: applications are typically configured with a single global instance
+    # of the exceptions reporter. use a thread local to store the current rack
+    # so different threads don't see the same request info
+    def self.rack_env
+      Thread.current[:exception_rack_env]
+    end
+
     def initialize(app, backend = nil)
       @app     = app
       @backend = backend
     end
 
     def call(env)
+      Thread.current[:exception_rack_env] = env
+
       begin
         response = @app.call(env)
       rescue Exception => e
-        backend.notify(e, rack_env: env)
+        backend.notify(e)
         raise
       end
 
       framework_exception = framework_exception(env)
       if framework_exception
-        backend.notify(framework_exception, rack_env: env)
+        backend.notify(framework_exception)
       end
 
       response
     ensure
       backend.clear_context
+      Thread.current[:exception_rack_env] = nil
     end
 
     private


### PR DESCRIPTION
travis is broken because of an integration spec, disregard

#### fix 1: fix issues reporting with an error string instead of an exception:
- rollbar will now send the backtrace
- rollbar will print the error class and error message properly. before
  this change, it would not include the error class

![proof](http://s.goobtown.net/ag9zfmdvb2JzaG90cy1ocmRyDQsSBFNob3QYouaDBQw)


#### fix 2: fix: send request data to rollbar even when reporting manually

