### PR TITLE
don't gen anonymous classes when reporting manual errors

### DIFF
--- a/lib/exceptions/backends/rollbar.rb
+++ b/lib/exceptions/backends/rollbar.rb
@@ -51,12 +51,9 @@ module Exceptions
         if error_class_or_exception_or_string.is_a?(Exception)
           error_class_or_exception_or_string
         else
-          Class.new(StandardError) do
-            define_singleton_method(:name) do
-              error_class_or_exception_or_string.to_s
-            end
-            define_method(:message) { error_message.to_s }
-          end.new
+          PlaceholderError.new(
+            class_name: error_class_or_exception_or_string.to_s,
+            error_message: error_message.to_s)
         end
       end
 
@@ -75,6 +72,21 @@ module Exceptions
       end
 
       RollbarExtractor = Object.new.extend(::Rollbar::RequestDataExtractor)
+
+      class PlaceholderError < StandardError
+        def initialize(class_name:, error_message:)
+          @class_name = class_name
+          @error_message = error_message
+        end
+
+        def class
+          OpenStruct.new(name: @class_name)
+        end
+
+        def message
+          @error_message
+        end
+      end
     end
   end
 end

--- a/spec/exceptions/backends/rollbar_spec.rb
+++ b/spec/exceptions/backends/rollbar_spec.rb
@@ -97,5 +97,20 @@ describe Exceptions::Backends::Rollbar do
       wrapped.call(env)
       expect(rollbar).to have_received(:scoped).with(request: request_data)
     end
+
+    it "passes along the error_class and error_message params" do
+      allow(app).to receive(:call) do
+        backend.notify(error_class: "MyError", error_message: "The message")
+        response
+      end
+      expect(rollbar).to receive(:log) do |level, error, description, extra|
+        expect(level).to eq("error")
+        expect(error.class.name).to eq("MyError")
+        expect(description).to eq("The message")
+        expect(extra).to eq(use_exception_level_filters: true)
+      end
+      wrapped.call(env)
+      expect(rollbar).to have_received(:scoped).with(request: request_data)
+    end
   end
 end


### PR DESCRIPTION
we were seeing an uptick in OOMs in r101-api around the same time we
released https://github.com/remind101/exceptions/pull/13. after
reverting that, the OOMs went away. so it could very well be the
anonymous classes causing the memory issues.

i figured out a way to do this without creating anonymous classes. it's
just as hax as the last approach, if not more hax, but the rollbar gem
is happy with it.

![proof](http://s.goobtown.net/ag9zfmdvb2JzaG90cy1ocmRyDQsSBFNob3QYkomIBQw)

---

just as last time, travis is failing because of the honeybadger integration spec. might just delete it. **update**: i disabled it.